### PR TITLE
King proximity with passed pawns

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 group=ratosh
-version=2.3.6
+version=2.3.7
 kotlin_version=1.2.50
 detekt_version=1.0.0.RC6-3

--- a/pirarucu-common/src/main/kotlin/pirarucu/eval/PawnEvaluator.kt
+++ b/pirarucu-common/src/main/kotlin/pirarucu/eval/PawnEvaluator.kt
@@ -194,6 +194,11 @@ object PawnEvaluator {
                 result += TunableConstants.PASSED_PAWN_BONUS[TunableConstants.PASSED_PAWN_DEFENDED_ADVANCE]
             }
 
+            result += TunableConstants.PASSED_PAWN_BONUS[TunableConstants.PASSED_PAWN_KING_DISTANCE] *
+                (Square.SQUARE_DISTANCE[pawnSquare][board.kingSquare[theirColor]] -
+                    Square.SQUARE_DISTANCE[pawnSquare][board.kingSquare[ourColor]])
+
+
             tmpPieces = tmpPieces and tmpPieces - 1
         }
 

--- a/pirarucu-common/src/main/kotlin/pirarucu/eval/PawnEvaluator.kt
+++ b/pirarucu-common/src/main/kotlin/pirarucu/eval/PawnEvaluator.kt
@@ -198,7 +198,6 @@ object PawnEvaluator {
                 (Square.SQUARE_DISTANCE[pawnSquare][board.kingSquare[theirColor]] -
                     Square.SQUARE_DISTANCE[pawnSquare][board.kingSquare[ourColor]])
 
-
             tmpPieces = tmpPieces and tmpPieces - 1
         }
 

--- a/pirarucu-common/src/main/kotlin/pirarucu/tuning/TunableConstants.kt
+++ b/pirarucu-common/src/main/kotlin/pirarucu/tuning/TunableConstants.kt
@@ -153,9 +153,10 @@ object TunableConstants {
     const val PASSED_PAWN_SAFE_PATH = 3
     const val PASSED_PAWN_DEFENDED = 4
     const val PASSED_PAWN_DEFENDED_ADVANCE = 5
+    const val PASSED_PAWN_KING_DISTANCE = 6
 
-    val PASSED_PAWN_BONUS_MG = intArrayOf(0, 30, 0, 0, 25, 0)
-    val PASSED_PAWN_BONUS_EG = intArrayOf(10, 10, 21, 21, 0, 17)
+    val PASSED_PAWN_BONUS_MG = intArrayOf(0, 29, 1, 0, 22, 0, 0)
+    val PASSED_PAWN_BONUS_EG = intArrayOf(4, 14, 20, 22, 0, 11, 7)
     val PASSED_PAWN_BONUS = IntArray(PASSED_PAWN_BONUS_EG.size)
 
     val PAWN_SHIELD_MG = arrayOf(

--- a/pirarucu-jvm/src/main/kotlin/pirarucu/benchmark/BenchmarkApplication.kt
+++ b/pirarucu-jvm/src/main/kotlin/pirarucu/benchmark/BenchmarkApplication.kt
@@ -42,6 +42,7 @@ object BenchmarkApplication {
         searchOptions.minSearchTimeLimit = 60000L
         searchOptions.maxSearchTimeLimit = 60000L
         searchOptions.searchTimeIncrement = 1000L
+        TranspositionTable.resize(16)
         val searchInfo = SearchInfo()
         val board = BoardFactory.getBoard()
         val startTime = Utils.specific.currentTimeMillis()

--- a/pirarucu-jvm/src/main/kotlin/pirarucu/tuning/texel/TexelTuningApplication.kt
+++ b/pirarucu-jvm/src/main/kotlin/pirarucu/tuning/texel/TexelTuningApplication.kt
@@ -1,6 +1,5 @@
 package pirarucu.tuning.texel
 
-import pirarucu.board.Piece
 import pirarucu.eval.EvalConstants
 import pirarucu.tuning.ErrorCalculator
 import pirarucu.tuning.TunableConstants
@@ -260,7 +259,6 @@ object TexelTuningApplication {
                 TunableConstants.MOBILITY_EG[Piece.QUEEN],
                 intArrayOf(8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8),
                 true, intArrayOf(), 5))
-                */
 
             tuningObject.registerTuningData(TexelTuningData(
                 "MOBILITY_MG[KING]",
@@ -274,7 +272,6 @@ object TexelTuningApplication {
                 intArrayOf(8, 8, 8, 8, 8, 8, 8, 8, 8),
                 true, intArrayOf(), 1))
 
-            /*
             tuningObject.registerTuningData(TexelTuningData(
                 "PAWN_SUPPORT_MG",
                 TunableConstants.PAWN_SUPPORT_MG,
@@ -322,19 +319,21 @@ object TexelTuningApplication {
                 TunableConstants.PASSED_PAWN_EG,
                 intArrayOf(0, 8, 8, 8, 8, 8, 8, 0),
                 true, intArrayOf(0, 7), 5))
+                */
 
             tuningObject.registerTuningData(TexelTuningData(
                 "PASSED_PAWN_BONUS_MG",
                 TunableConstants.PASSED_PAWN_BONUS_MG,
-                intArrayOf(8, 8, 8, 8, 8, 8),
-                false, intArrayOf(), 5))
+                intArrayOf(8, 8, 8, 8, 8, 8, 8),
+                false, intArrayOf(), 1))
 
             tuningObject.registerTuningData(TexelTuningData(
                 "PASSED_PAWN_BONUS_EG",
                 TunableConstants.PASSED_PAWN_BONUS_EG,
-                intArrayOf(8, 8, 8, 8, 8, 8),
-                false, intArrayOf(), 5))
+                intArrayOf(8, 8, 8, 8, 8, 8, 8),
+                false, intArrayOf(), 1))
 
+            /*
             tuningObject.registerTuningData(TexelTuningData(
                 "PAWN_SHIELD_MG[0][0]",
                 TunableConstants.PAWN_SHIELD_MG[0][0],


### PR DESCRIPTION
Bench | 9227810

ELO   | 8.73 +- 7.88 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.24 (-2.20, 2.20) [-1.50, 4.50]
Games | N: 4140 W: 1200 L: 1096 D: 1844

ELO   | 11.07 +- 8.60 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 2.24 (-2.20, 2.20) [-1.50, 4.50]
Games | N: 2950 W: 742 L: 648 D: 1560