### PR TITLE
QSearch futility

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 group=ratosh
-version=2.3.8
+version=2.3.9
 kotlin_version=1.2.50
 detekt_version=1.0.0.RC6-3

--- a/pirarucu-common/src/main/kotlin/pirarucu/eval/StaticExchangeEvaluator.kt
+++ b/pirarucu-common/src/main/kotlin/pirarucu/eval/StaticExchangeEvaluator.kt
@@ -7,7 +7,6 @@ import pirarucu.board.Piece
 import pirarucu.board.Square
 import pirarucu.move.BitboardMove
 import pirarucu.move.Move
-import pirarucu.stats.Statistics
 import pirarucu.tuning.TunableConstants
 import kotlin.math.max
 

--- a/pirarucu-common/src/main/kotlin/pirarucu/search/QuiescenceSearch.kt
+++ b/pirarucu-common/src/main/kotlin/pirarucu/search/QuiescenceSearch.kt
@@ -66,8 +66,7 @@ class QuiescenceSearch {
             }
 
             // Qsearch Futility
-            val capturedPiece = board.pieceTypeBoard[Move.getToSquare(move)]
-            val futilityValue = eval + TunableConstants.QS_FUTILITY_VALUE[capturedPiece]
+            val futilityValue = eval + getMoveValue(board, Move.getToSquare(move), moveType)
             if (futilityValue <= bestScore) {
                 continue
             }
@@ -95,4 +94,21 @@ class QuiescenceSearch {
         moveList.endPly()
         return bestScore
     }
+
+    private fun getMoveValue(board: Board, toSquare: Int, moveType: Int): Int {
+        return when {
+            moveType == MoveType.TYPE_PASSANT -> {
+                TunableConstants.QS_FUTILITY_VALUE[Piece.PAWN]
+            }
+            MoveType.isPromotion(moveType) -> {
+                TunableConstants.QS_FUTILITY_VALUE[board.pieceTypeBoard[toSquare]] -
+                    TunableConstants.QS_FUTILITY_VALUE[Piece.PAWN] +
+                    TunableConstants.QS_FUTILITY_VALUE[MoveType.getPromotedPiece(moveType)]
+            }
+            else -> {
+                TunableConstants.QS_FUTILITY_VALUE[board.pieceTypeBoard[toSquare]]
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
Improve futility accuracy.

Bench | 8763479

ELO   | 9.75 +- 8.76 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.32 (-2.20, 2.20) [-5.00, 0.00]
Games | N: 3280 W: 938 L: 846 D: 1496

ELO   | 6.58 +- 7.06 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 2.21 (-2.20, 2.20) [-5.00, 0.00]
Games | N: 4120 W: 952 L: 874 D: 2294

