### PR TITLE
Killer reduction

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 group=ratosh
-version=2.5.2
+version=2.5.3
 kotlin_version=1.2.50
 detekt_version=1.0.0.RC6-3

--- a/pirarucu-common/src/main/kotlin/pirarucu/search/MainSearch.kt
+++ b/pirarucu-common/src/main/kotlin/pirarucu/search/MainSearch.kt
@@ -278,6 +278,10 @@ class MainSearch(private val searchOptions: SearchOptions, private val searchInf
                     !isPromotion) {
 
                     reduction = TunableConstants.LMR_TABLE[min(newDepth, 63)][min(movesPerformed, 63)]
+
+                    if (currentNode.isKillerMove(move)) {
+                        reduction -= 1
+                    }
                     if (!pvNode) {
                         reduction += 1
                     }


### PR DESCRIPTION
Bench | 10601757

ELO   | 9.70 +- 8.35 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.23 (-2.20, 2.20) [-1.50, 4.50]
Games | N: 3620 W: 1036 L: 935 D: 1649

ELO   | 15.45 +- 10.24 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 2.20 (-2.20, 2.20) [-1.50, 4.50]
Games | N: 1980 W: 487 L: 399 D: 1094