### PR TITLE
Time management changes

### DIFF
--- a/pirarucu-common/src/main/kotlin/pirarucu/search/SearchOptions.kt
+++ b/pirarucu-common/src/main/kotlin/pirarucu/search/SearchOptions.kt
@@ -57,6 +57,6 @@ class SearchOptions {
         private const val GAME_MOVES = 40L
         private const val MIN_GAME_MOVES = 15L
 
-        private const val INCREMENT_RATIO = 30
+        private const val INCREMENT_RATIO = 40
     }
 }


### PR DESCRIPTION
Increase the increment multiplier from 30 to 40.

ELO   | -0.22 +- 4.78 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | -1.46 (-1.39, 1.39) [0.00, 5.00]
Games | N: 10980 W: 2970 L: 2977 D: 5033

ELO   | 13.86 +- 12.06 (95%)
SPRT  | 60.0+0.3s Threads=1 Hash=64MB
LLR   | 1.45 (-1.39, 1.39) [-1.50, 4.50]
Games | N: 1480 W: 373 L: 314 D: 793