### PR TITLE
Safe check tuning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@
 hs_err_pid*
 
 # Intellij
+*.iml
 .idea/
 .gradle/
 build/

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 group=ratosh
-version=2.9.6
+version=2.9.7
 kotlin_version=1.3.0
 detekt_version=1.0.0.RC6-3

--- a/pirarucu-common/src/main/kotlin/pirarucu/tuning/TunableConstants.kt
+++ b/pirarucu-common/src/main/kotlin/pirarucu/tuning/TunableConstants.kt
@@ -214,8 +214,8 @@ object TunableConstants {
     val KING_THREAT_EG = intArrayOf(0, 0, -1, 2, 1, 8, 0)
     val KING_THREAT = IntArray(Piece.SIZE)
 
-    val SAFE_CHECK_THREAT_MG = intArrayOf(0, 0, 115, 14, 87, 28, 0)
-    val SAFE_CHECK_THREAT_EG = intArrayOf(0, 0, 2, 33, 0, 94, 0)
+    val SAFE_CHECK_THREAT_MG = intArrayOf(0, 0, 117, 14, 87, 30, 0)
+    val SAFE_CHECK_THREAT_EG = intArrayOf(0, 0, 5, 33, 1, 99, 0)
     val SAFE_CHECK_THREAT = IntArray(Piece.SIZE)
 
     const val OTHER_BONUS_BISHOP_PAIR = 0


### PR DESCRIPTION
Bench | 8423973

ELO   | 3.91 +- 5.86 (95%)
SPRT  | 10.0+0.05s Threads=1 Hash=8MB
LLR   | 1.41 (-1.39, 1.39) [-1.50, 4.50]
Games | N: 6840 W: 1773 L: 1696 D: 3371

ELO   | 11.87 +- 10.98 (95%)
SPRT  | 60.0+0.3s Threads=1 Hash=64MB
LLR   | 1.39 (-1.39, 1.39) [-1.50, 4.50]
Games | N: 1640 W: 378 L: 322 D: 940