### PR TITLE
Pawn structure tuning

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 group=ratosh
-version=2.9.8
+version=2.9.9
 kotlin_version=1.3.0
 detekt_version=1.0.0.RC6-3

--- a/pirarucu-common/src/main/kotlin/pirarucu/tuning/TunableConstants.kt
+++ b/pirarucu-common/src/main/kotlin/pirarucu/tuning/TunableConstants.kt
@@ -157,8 +157,8 @@ object TunableConstants {
     const val PAWN_STRUCTURE_BACKWARD = 4
     const val PAWN_STRUCTURE_BACKWARD_HALF_OPEN = 5
 
-    val PAWN_STRUCTURE_MG = intArrayOf(23, 9, -12, -6, -2, -20)
-    val PAWN_STRUCTURE_EG = intArrayOf(4, -1, -12, -11, -9, -16)
+    val PAWN_STRUCTURE_MG = intArrayOf(25, 10, -10, -4, -3, -22)
+    val PAWN_STRUCTURE_EG = intArrayOf(6, 1, -10, -12, -10, -16)
     val PAWN_STRUCTURE = IntArray(PAWN_STRUCTURE_EG.size)
 
     val PASSED_PAWN_MG = intArrayOf(0, -7, -8, -18, 3, 7, 104, 0)


### PR DESCRIPTION
Bench | 8017558

ELO   | 2.55 +- 4.15 (95%)
SPRT  | 10.0+0.05s Threads=1 Hash=8MB
LLR   | 1.43 (-1.39, 1.39) [-1.50, 4.50]
Games | N: 13900 W: 3653 L: 3551 D: 6696

ELO   | 3.81 +- 5.43 (95%)
SPRT  | 60.0+0.3s Threads=1 Hash=64MB
LLR   | 1.47 (-1.39, 1.39) [-1.50, 4.50]
Games | N: 6740 W: 1485 L: 1411 D: 3844