### PR TITLE
King threat tuning

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 group=ratosh
-version=3.0.0
+version=3.0.1
 kotlin_version=1.3.0
 detekt_version=1.0.0.RC6-3

--- a/pirarucu-common/src/main/kotlin/pirarucu/tuning/TunableConstants.kt
+++ b/pirarucu-common/src/main/kotlin/pirarucu/tuning/TunableConstants.kt
@@ -214,8 +214,8 @@ object TunableConstants {
     val PAWN_PUSH_THREAT_EG = intArrayOf(0, 0, 18, 11, 8, 9, 15)
     val PAWN_PUSH_THREAT = IntArray(PAWN_PUSH_THREAT_EG.size)
 
-    val KING_THREAT_MG = intArrayOf(0, 0, 10, 11, 7, 10, 0)
-    val KING_THREAT_EG = intArrayOf(0, 0, -1, 2, 1, 8, 0)
+    val KING_THREAT_MG = intArrayOf(0, 0, 12, 13, 11, 14, 0)
+    val KING_THREAT_EG = intArrayOf(0, 0, -2, 2, -2, 11, 0)
     val KING_THREAT = IntArray(Piece.SIZE)
 
     val SAFE_CHECK_THREAT_MG = intArrayOf(0, 0, 117, 14, 87, 30, 0)


### PR DESCRIPTION
Bench | 8093097

ELO   | 5.01 +- 6.95 (95%)
SPRT  | 10.0+0.05s Threads=1 Hash=8MB
LLR   | 1.45 (-1.39, 1.39) [-1.50, 4.50]
Games | N: 5270 W: 1488 L: 1412 D: 2370

ELO   | 4.83 +- 6.57 (95%)
SPRT  | 60.0+0.3s Threads=1 Hash=64MB
LLR   | 1.41 (-1.39, 1.39) [-1.50, 4.50]
Games | N: 4820 W: 1116 L: 1049 D: 2655
