### PR TITLE
Better support on UCI go command

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 group=ratosh
-version=3.0.8
+version=3.0.9
 kotlin_version=1.3.0
 detekt_version=1.0.0.RC6-3

--- a/pirarucu-common/src/main/kotlin/pirarucu/search/MainSearch.kt
+++ b/pirarucu-common/src/main/kotlin/pirarucu/search/MainSearch.kt
@@ -484,7 +484,10 @@ class MainSearch(
                 val previousScore = score
 
                 score = search(board, depth, 0, alpha, beta, true)
+
+                val currentTime = PlatformSpecific.currentTimeMillis()
                 if (searchOptions.stop) {
+                    searchInfoListener.searchInfo(depth, currentTime - searchOptions.startTime, searchInfo)
                     break
                 }
 
@@ -518,8 +521,6 @@ class MainSearch(
                         wantedSearchTime -= searchTimeIncrement
                     }
                 }
-
-                val currentTime = PlatformSpecific.currentTimeMillis()
 
                 searchInfo.save(board)
                 searchInfoListener.searchInfo(depth, currentTime - searchOptions.startTime, searchInfo)

--- a/pirarucu-common/src/main/kotlin/pirarucu/search/MainSearch.kt
+++ b/pirarucu-common/src/main/kotlin/pirarucu/search/MainSearch.kt
@@ -60,8 +60,8 @@ class MainSearch(
 
         searchInfo.searchNodes++
         if (!rootNode &&
+            searchInfo.searchNodes and 0xFFFFL == 0xFFFFL &&
             searchOptions.hasTimeLimit &&
-            searchInfo.searchNodes and 0xFFFL == 0xFFFL &&
             searchOptions.maxSearchTimeLimit < PlatformSpecific.currentTimeMillis()
         ) {
             searchOptions.stop = true

--- a/pirarucu-common/src/main/kotlin/pirarucu/search/MainSearch.kt
+++ b/pirarucu-common/src/main/kotlin/pirarucu/search/MainSearch.kt
@@ -60,6 +60,7 @@ class MainSearch(
 
         searchInfo.searchNodes++
         if (!rootNode &&
+            searchOptions.hasTimeLimit &&
             searchInfo.searchNodes and 0xFFFL == 0xFFFL &&
             searchOptions.maxSearchTimeLimit < PlatformSpecific.currentTimeMillis()
         ) {
@@ -487,7 +488,10 @@ class MainSearch(
                     break
                 }
 
-                if (depth > 4) {
+                if (searchOptions.hasTimeLimit &&
+                    !searchOptions.hasFixedTime &&
+                    depth > 4
+                ) {
                     if (score < previousScore &&
                         wantedSearchTime < searchOptions.maxSearchTimeLimit
                     ) {
@@ -520,7 +524,7 @@ class MainSearch(
                 searchInfo.save(board)
                 searchInfoListener.searchInfo(depth, currentTime - searchOptions.startTime, searchInfo)
 
-                if (wantedSearchTime < currentTime) {
+                if (searchOptions.hasTimeLimit && wantedSearchTime < currentTime) {
                     searchOptions.stop = true
                     break
                 }

--- a/pirarucu-common/src/main/kotlin/pirarucu/search/SearchOptions.kt
+++ b/pirarucu-common/src/main/kotlin/pirarucu/search/SearchOptions.kt
@@ -10,6 +10,8 @@ class SearchOptions {
 
     // Search control
     var stop = false
+    var hasTimeLimit = true
+    var hasFixedTime = false
     var startTime = 0L
     var maxSearchTimeLimit = 0L
     var minSearchTimeLimit = 0L
@@ -28,6 +30,9 @@ class SearchOptions {
     var blackIncrement = 0L
 
     fun setTime(color: Int) {
+        if (!hasTimeLimit || hasFixedTime) {
+            return
+        }
         val moves = when {
             movesToGo != 0L -> max(movesToGo * 2, movesToGo + MIN_GAME_MOVES)
             else -> GAME_MOVES
@@ -53,8 +58,11 @@ class SearchOptions {
     fun startControl() {
         stop = false
         startTime = PlatformSpecific.currentTimeMillis()
-        maxSearchTimeLimit = startTime + maxSearchTime
+        if (!hasTimeLimit) {
+            return
+        }
         minSearchTimeLimit = startTime + minSearchTime
+        maxSearchTimeLimit = startTime + maxSearchTime
     }
 
     companion object {

--- a/pirarucu-jvm/src/main/kotlin/pirarucu/benchmark/Benchmark.kt
+++ b/pirarucu-jvm/src/main/kotlin/pirarucu/benchmark/Benchmark.kt
@@ -29,9 +29,7 @@ object Benchmark {
         val mainSearch =
             MainSearch(searchOptions, SimpleSearchInfoListener(), transpositionTable, PawnEvaluationCache(4), History())
         searchOptions.depth = depth
-        searchOptions.minSearchTime = 60000L
-        searchOptions.maxSearchTime = 60000L
-        searchOptions.searchTimeIncrement = 1000L
+        searchOptions.hasTimeLimit = false
         val board = BoardFactory.getBoard()
         val startTime = PlatformSpecific.currentTimeMillis()
         for (epdInfo in iterator) {

--- a/pirarucu-jvm/src/main/kotlin/pirarucu/uci/InputHandler.kt
+++ b/pirarucu-jvm/src/main/kotlin/pirarucu/uci/InputHandler.kt
@@ -1,6 +1,7 @@
 package pirarucu.uci
 
 import pirarucu.board.factory.BoardFactory
+import pirarucu.game.GameConstants
 import pirarucu.search.MultiThreadedSearch
 import pirarucu.tuning.TunableConstants
 import pirarucu.util.Perft
@@ -20,14 +21,23 @@ class InputHandler : IInputHandler {
 
     override fun search(tokens: Array<String>) {
         var index = 1
+        MultiThreadedSearch.searchOptions.hasFixedTime = false
+        MultiThreadedSearch.searchOptions.hasTimeLimit = true
+        MultiThreadedSearch.searchOptions.depth = GameConstants.MAX_PLIES - 1
         while (index < tokens.size) {
             when (tokens[index]) {
                 "infinite" -> {
-                    MultiThreadedSearch.searchOptions.whiteTime = Long.MAX_VALUE
-                    MultiThreadedSearch.searchOptions.blackTime = Long.MAX_VALUE
-                    MultiThreadedSearch.searchOptions.whiteIncrement = 0L
-                    MultiThreadedSearch.searchOptions.blackIncrement = 0L
-                    MultiThreadedSearch.searchOptions.movesToGo = 1L
+                    MultiThreadedSearch.searchOptions.hasTimeLimit = false
+                }
+                "depth" -> {
+                    MultiThreadedSearch.searchOptions.hasTimeLimit = false
+                    MultiThreadedSearch.searchOptions.depth = tokens[index + 1].toInt()
+                }
+                "movetime" -> {
+                    MultiThreadedSearch.searchOptions.hasFixedTime = true
+                    val timeLimit = tokens[index + 1].toLong()
+                    MultiThreadedSearch.searchOptions.minSearchTime = timeLimit
+                    MultiThreadedSearch.searchOptions.maxSearchTime = timeLimit
                 }
                 "wtime" -> MultiThreadedSearch.searchOptions.whiteTime = tokens[index + 1].toLong()
                 "btime" -> MultiThreadedSearch.searchOptions.blackTime = tokens[index + 1].toLong()

--- a/pirarucu-util/src/main/kotlin/pirarucu/epd/EpdFileWriter.kt
+++ b/pirarucu-util/src/main/kotlin/pirarucu/epd/EpdFileWriter.kt
@@ -19,7 +19,7 @@ class EpdFileWriter(private val file: File) {
                     val epdInfo = findPosition(line, epdInfoList)
                     writer.println(
                         when {
-                            epdInfo != null -> "${epdInfo.fenPosition} c9 ${Math.round(ErrorUtil.calculateSigmoid(epdInfo.eval))}.0"
+                            epdInfo != null -> "${epdInfo.fenPosition} c9 %.1f".format(ErrorUtil.calculateSigmoid(epdInfo.eval))
                             else -> line
                         }
                     )

--- a/pirarucu-util/src/main/kotlin/pirarucu/testing/TestingApplication.kt
+++ b/pirarucu-util/src/main/kotlin/pirarucu/testing/TestingApplication.kt
@@ -37,9 +37,7 @@ object TestingApplication {
         val history = History()
         val mainSearch = MainSearch(searchOptions, SimpleSearchInfoListener(), transpositionTable, pawnCache, history)
         searchOptions.depth = depth
-        searchOptions.minSearchTime = 60000L
-        searchOptions.maxSearchTime = 60000L
-        searchOptions.searchTimeIncrement = 60000L
+        searchOptions.hasTimeLimit = false
         val board = BoardFactory.getBoard()
         var partialScore = 0
         for ((index, epdInfo) in testFile.epdList.withIndex()) {

--- a/pirarucu-util/src/main/kotlin/pirarucu/tuning/SearchErrorEvaluator.kt
+++ b/pirarucu-util/src/main/kotlin/pirarucu/tuning/SearchErrorEvaluator.kt
@@ -72,9 +72,8 @@ class SearchErrorEvaluator(private val threads: Int = 1) {
         override fun evaluate() {
             val searchOptions = SearchOptions()
             searchOptions.depth = depth
-            searchOptions.minSearchTime = 60000L
-            searchOptions.maxSearchTime = 60000L
-
+            searchOptions.hasTimeLimit = false
+            
             val transpositionTable = TranspositionTable(ttSize)
             val pawnEvaluationCache = PawnEvaluationCache(ttSize)
             val history = History()


### PR DESCRIPTION
Regarding issue #176 

- Support "go depth [Number]"
- Support "go movetime [Number]"
- Support "go infinite"

ELO   | -1.21 +- 2.18 (95%)
SPRT  | 10.0+0.05s Threads=1 Hash=8MB
LLR   | 2.25 (-2.20, 2.20) [-5.00, 0.00]
Games | N: 50910 W: 13203 L: 13380 D: 24327