### PR TITLE
Tuning history pruning

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 group=ratosh
-version=3.1.7
+version=3.1.8
 kotlin_version=1.3.0
 detekt_version=1.0.0.RC6-3

--- a/pirarucu-common/src/main/kotlin/pirarucu/tuning/TunableConstants.kt
+++ b/pirarucu-common/src/main/kotlin/pirarucu/tuning/TunableConstants.kt
@@ -16,7 +16,7 @@ object TunableConstants {
     val FUTILITY_CHILD_MARGIN = intArrayOf(0, 100, 160, 230, 310, 400, 500)
     val FUTILITY_PARENT_MARGIN = intArrayOf(0, 100, 200, 310, 430, 550, 660)
 
-    val FUTILITY_HISTORY_MARGIN = intArrayOf(0, -14000, -14500, -14500, -15000, -15500, -16000)
+    val FUTILITY_HISTORY_MARGIN = intArrayOf(0, -12500, -13000, -15500, -17000, -18000, -19000)
 
     val TEMPO_TUNING = intArrayOf(23, 13)
     val TEMPO = IntArray(Color.SIZE)

--- a/pirarucu-util/src/main/kotlin/pirarucu/benchmark/BenchmarkApplication.kt
+++ b/pirarucu-util/src/main/kotlin/pirarucu/benchmark/BenchmarkApplication.kt
@@ -2,7 +2,7 @@ package pirarucu.benchmark
 
 fun main() {
     val speed = LongArray(1)
-    for (tries in 0 until speed.size) {
+    for (tries in speed.indices) {
         speed[tries] = Benchmark.runBenchmark()
     }
     println("Time taken " + speed.sum())


### PR DESCRIPTION
Bench | 9226345

ELO   | 18.68 +- 10.21 (95%)
SPRT  | 10.0+0.05s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [-1.50, 4.50]
Games | N: 2290 W: 650 L: 527 D: 1113

ELO   | 10.53 +- 7.00 (95%)
SPRT  | 60.0+0.3s Threads=1 Hash=64MB
LLR   | 2.97 (-2.94, 2.94) [-1.50, 4.50]
Games | N: 3960 W: 889 L: 769 D: 2302