### PR TITLE
Piece value

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 group=ratosh
-version=3.2.4
+version=3.2.5
 kotlin_version=1.3.0
 detekt_version=1.0.0.RC6-3

--- a/pirarucu-common/src/main/kotlin/pirarucu/tuning/TunableConstants.kt
+++ b/pirarucu-common/src/main/kotlin/pirarucu/tuning/TunableConstants.kt
@@ -27,8 +27,8 @@ object TunableConstants {
             PHASE_PIECE_VALUE[Piece.ROOK] * 4 +
             PHASE_PIECE_VALUE[Piece.QUEEN] * 2
 
-    val MATERIAL_SCORE_MG = intArrayOf(0, 87, 476, 508, 682, 1446)
-    val MATERIAL_SCORE_EG = intArrayOf(0, 116, 327, 352, 606, 1082)
+    val MATERIAL_SCORE_MG = intArrayOf(0, 87, 460, 480, 652, 1294)
+    val MATERIAL_SCORE_EG = intArrayOf(0, 132, 401, 426, 717, 1380)
     val MATERIAL_SCORE = IntArray(Piece.SIZE)
 
     val QS_FUTILITY_VALUE = IntArray(Piece.SIZE)


### PR DESCRIPTION
Bench | 9163461

ELO   | 5.21 +- 4.90 (95%)
SPRT  | 10.0+0.05s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [-1.50, 4.50]
Games | N: 9810 W: 2573 L: 2426 D: 4811

ELO   | 4.48 +- 4.22 (95%)
SPRT  | 60.0+0.3s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [-1.50, 4.50]
Games | N: 10700 W: 2272 L: 2134 D: 6294